### PR TITLE
feat: multi-level permissions for functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,19 @@ Attempting to call a level‑2 function from a level‑0 or level‑1 function r
 ;; > elser: invalid permissions: fn emergencyWithdraw | have {:r 1, :w 0} | want {:r 1, :w 2}
 (defn withdraw [(amount :u256)] @sto{:w 0 :r 1} (-> []) 
   (invoke! emergencyWithdraw))
-``` 
+```
+
+The multi-level privilege relations can be represented via such diagram:
+```mermaid
+flowchart TD
+    A(["emergencyWithdraw"]) <--> B(["pause"])
+    A --> n1(["withdraw"])
+    B --> n1
+    n1 --x B & A
+    style A fill:#C8E6C9
+    style B fill:#C8E6C9
+    style n1 fill:#BBDEFB
+```
 
 #### Function Returns
 Return parameters are also immutable by default, and should be explicitly marked as `mut` to map values to them. All functions should include return syntax, even if they don't return anything:

--- a/examples/counter.els
+++ b/examples/counter.els
@@ -2,7 +2,7 @@
 
 (storage
  {:external
-  [(def count [(x mut :u256)])]})
+  [(def count [(x :u256)])]})
 
 (functions
  {:external

--- a/examples/etherWallet.els
+++ b/examples/etherWallet.els
@@ -2,7 +2,7 @@
 
 (constructor (sto write! owner (caller)))
 
-(storage {:external [(def owner [(o mut :addr)])]})
+(storage {:external [(def owner [(o :addr)])]})
 
 (functions
  {:external

--- a/examples/pausableEtherWallet.els
+++ b/examples/pausableEtherWallet.els
@@ -1,0 +1,65 @@
+(ns pausableEtherWallet (:pragma "0.8.30"))
+
+(constructor (sto write! owner (caller)))
+
+(events
+ [
+ (def Paused [(acc :u256)])
+ (def Unpaused [(acc :u256)])
+ ])
+
+(constants
+ {:internal [
+ ;; The operation failed because the contract is paused.
+ (def ERR_ENFORCED_PAUSE [(e :u256)] 69)
+ ;; The operation failed because the contract is not paused.
+ (def ERR_EXPECTED_PAUSE [(e :u256)] 70)
+ ]})
+
+(storage
+ {:external [
+ (def owner [(o :addr)])
+ (def paused [(p :bool)])
+ ]})
+
+(functions
+ {:external
+ [
+ (defn emergencyWithdraw [] @sto{:w 2 :r 1} (-> [])
+   (do
+    (invoke! onlyOwner)
+    (invoke! withdraw (balance (self)))
+     (invoke! pause)))
+ 
+ (defn withdraw [(amount :u256)] @sto{:w 0 :r 1} (-> [])
+   (do (invoke! onlyOwner)
+       (transfer* (caller) amount)))
+
+ (defn getBalance [] @sto{:w 0 :r 0} (-> [(b mut :u256)])
+   (-> b (balance (self))))
+ ]
+ 
+ :internal [
+ 
+ ;; Triggers stopped state.
+ (defn pause [] @sto{:w 2 :r 1} (-> [])
+   (do (invoke! requireNotPaused)
+       (sto write! paused true)))
+
+ ;; Returns to normal state. 
+ (defn unpause [] @sto{:w 2 :r 1} (-> [])
+   (do (invoke! requirePaused)
+       (sto write! paused false)))
+ 
+ (defn requireNotPaused [] @sto{:w 0 :r 1} (-> [])
+   (require (sto read! paused) ERR_ENFORCED_PAUSE))
+
+ (defn requirePaused [] @sto{:w 0 :r 1} (-> [])
+   (require (not (sto read! paused)) ERR_ENFORCED_PAUSE))
+
+
+ (defn onlyOwner [] @sto{:w 0 :r 1} (-> [])
+   (assert (= (caller) (sto read! owner))))
+ ] 
+ })
+

--- a/examples/purchase.els
+++ b/examples/purchase.els
@@ -11,10 +11,10 @@
 (storage
  {:external
  [
- (def value [(v mut :u256)])
- (def seller [(s mut :addr)])
- (def buyer [(b mut :addr)])
- (def state [(s mut :u256)])]})
+ (def value [(v :u256)])
+ (def seller [(s :addr)])
+ (def buyer [(b :addr)])
+ (def state [(s :u256)])]})
 
 (events
  [

--- a/examples/random.els
+++ b/examples/random.els
@@ -1,9 +1,8 @@
 (ns math (:pragma "0.8.29"))
 
 (storage
- {:internal [
- 
- (def result [(x mut :u256)])
+ {:internal [ 
+ (def result [(x :u256)])
  (def truth [(t :bool)])
  (def temp [(t :addr)])
  (def buyer [(t :addr)])

--- a/src/elser/errors.clj
+++ b/src/elser/errors.clj
@@ -81,5 +81,8 @@
   (throw (Exception. (format "elser: invalid permissions: fn %s | have %s | want %s"
                              f h w))))
 
+(defn err-sto-access-non-int [a]
+  (throw (Exception. (format "elser: invalid type for @sto access valie: %s" a))))
+
 (defn err-diff-types-comp [x y]
   (throw (Exception. (format "elser: comparing diff types: x %s | y %s" x y))))


### PR DESCRIPTION
## Overview
- Extends sets for `:w` `:r` of `@sto` to include integers in range {0,1,2,3}, essentially representing multi-level permissions for functions.

## Related Issues
- Closes #18 