### PR TITLE
feat: improve error reporting

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,8 @@
   
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [org.clojure/tools.cli "1.1.230"]
-                 [org.web3j/core "4.13.0"]]
+                 [org.web3j/core "4.13.0"]
+                 [clansi "1.0.0"]]
 
   
   :target-path "target/%s"

--- a/src/elser/compiler.clj
+++ b/src/elser/compiler.clj
@@ -71,7 +71,7 @@
       (doseq [[k v] sto-ns] (env/eset sto-env k v)))
     sto-env))
 
-(declare compile)
+(declare compile-elser)
 
 (defn compile-symbols
   [symbols yul-env sto-env]
@@ -79,19 +79,19 @@
     (symbol? symbols) (env/eget yul-env symbols)
     
     (map? symbols) (let [k (keys symbols)
-                         v (doall (map (fn [x] (compile x yul-env sto-env))
+                         v (doall (map (fn [x] (compile-elser x yul-env sto-env))
                                        (vals symbols)))]
                      (zipmap k v))
     
-    (seq? symbols) (mapv (fn [x] (compile x yul-env sto-env))
+    (seq? symbols) (mapv (fn [x] (compile-elser x yul-env sto-env))
                          symbols)
     
-    (vector? symbols) (mapv (fn [x] (compile x yul-env sto-env))
+    (vector? symbols) (mapv (fn [x] (compile-elser x yul-env sto-env))
                             symbols)
     
     :else symbols))
 
-(defn compile
+(defn compile-elser
   [symbols yul-env sto-env]
   (cond
     ;; TODO: what to do wtih this case?
@@ -118,7 +118,7 @@
                                                      (format
                                                       "let %s := %s"
                                                       (first l)
-                                                      (compile
+                                                      (compile-elser
                                                        (nth l 1)
                                                        let-env
                                                        sto-env
@@ -130,7 +130,7 @@
                          ;; Execute 'let' body.
                          (str yul-lets "\n"
                               (string/join "\n"
-                                           (mapv (fn [i] (compile (nth symbols i)
+                                           (mapv (fn [i] (compile-elser (nth symbols i)
                                                                  let-env sto-env))
                                                  (range 2 (count symbols))))))
 
@@ -138,7 +138,7 @@
                        ;; (it doesn't return anything).
                        (= f 'do)
                        (let [exprs (mapv
-                                    (fn [sym] (compile
+                                    (fn [sym] (compile-elser
                                               sym
                                               yul-env
                                               sto-env
@@ -150,14 +150,14 @@
 
                        ;; 'invoke!' - function invocation.
                        (= f 'invoke!)
-                       (compile (rest symbols) yul-env sto-env)
+                       (compile-elser (rest symbols) yul-env sto-env)
 
                        ;; 'loop' in Yul (loop [binds] (cond) (post-iter) (body))
                        ;; in elser (loop [binds] (cond) (body) (post-iter)).
                        (= f 'loop)
                        (let [loop-env (env/env yul-env)
                              ;; Compile bindings like 'let'.
-                             yul-lets (compile
+                             yul-lets (compile-elser
                                        (list 'let (first (rest symbols)) nil)
                                        loop-env sto-env)
                              [_ _ cnd body post-iter] symbols
@@ -177,15 +177,15 @@
 
                          (format "for { %s } %s { %s }\n { %s }\n"
                                  yul-lets
-                                 (compile (second cnd) loop-env sto-env)
+                                 (compile-elser (second cnd) loop-env sto-env)
                                  ;; Execute 'step' block as 'do'.
-                                 (compile (cons 'do (rest post-iter))
+                                 (compile-elser (cons 'do (rest post-iter))
                                           loop-env sto-env)
-                                 (compile body loop-env sto-env)))
+                                 (compile-elser body loop-env sto-env)))
 
                        (= f 'transfer*)
-                       (let [to (compile (second symbols) yul-env sto-env)
-                             value (compile (last symbols) yul-env sto-env)]
+                       (let [to (compile-elser (second symbols) yul-env sto-env)
+                             value (compile-elser (last symbols) yul-env sto-env)]
                          (format "pop(call(gas(),%s,%s,0,0,0,0))" to value))
                        
 

--- a/src/elser/errors.clj
+++ b/src/elser/errors.clj
@@ -1,7 +1,11 @@
 (ns elser.errors
-  (:gen-class))
+  (:gen-class)
+  (:require [elser.printer :as printer]))
 
 (defn err-eof-before-paren [] (throw (Exception. "elser: EOF before ')'")))
+
+(defn err-throw [metadata]
+  (throw (Exception. (printer/fmt-err metadata))))
 
 (defn err-unexpected-tkn [s]
   (throw (Exception. (format "elser: unexpected token: %s" s))))

--- a/src/elser/errors.clj
+++ b/src/elser/errors.clj
@@ -2,13 +2,12 @@
   (:gen-class)
   (:require [elser.printer :as printer]))
 
-(defn err-eof-before-paren [] (throw (Exception. "elser: EOF before ')'")))
-
 (defn err-throw [metadata]
   (throw (Exception. (printer/fmt-err metadata))))
 
-(defn err-unexpected-tkn [s]
-  (throw (Exception. (format "elser: unexpected token: %s" s))))
+(defn unexpected-token [t] (format "Unexpected token: '%s'" t))
+
+(defn err-eof-before-paren [] (throw (Exception. "elser: EOF before ')'")))
 
 (defn err-unbalanced
   [s]

--- a/src/elser/main.clj
+++ b/src/elser/main.clj
@@ -2,6 +2,7 @@
   (:gen-class)
   (:require [elser.env :as env]
             [elser.reader :as reader]
+            [elser.printer :as printer]
             [elser.errors :as errs]
             [elser.core :as core]
             [elser.symtable :as symtable]
@@ -9,10 +10,10 @@
             [elser.compiler :as compiler]
             [elser.evmcodegen :as evmcodegen]            
             [elser.cli :as cli]
-            [clojure.repl :as clj-repl]
-            [clojure.pprint :refer [pprint]]))
+            [elser.constants :as const]
+            [clojure.repl :as clj-repl]))
 
-(def prompt (fn [] (print ">>> ") (flush)))
+;;; --------------------------------- Initializing Environments ---------------------------------
 
 (def yul-env (env/env))
 (doseq [[k v] core/yul-ns] (env/eset yul-env k v))
@@ -20,54 +21,64 @@
 (def types-env (env/env))
 (doseq [[k v] core/types-ns] (env/eset types-env k v))
 
-(defn READ
-  [inp src]
-  (reader/read-str inp src))
+;;; --------------------------------- REPL ---------------------------------
 
-(defn rep
+(defn READ [inp src] (reader/read-str inp src))
+
+(defn read-eval-print
   [inp]
   (let [ast (READ inp "./")]
     (symtable/collect-symbols `(constructor ~ast))))
 
 (defn repl-loop []
-  (prompt)
-  (let [line (read-line)]
-    ; Skip comments
-    (if (not= \; (get line 0))
-      (try
-        (println (rep line))
-        (catch Throwable e (clj-repl/pst e))))
-      (recur)))
+  (const/elser-prompt)
 
-(defn process-file [file options]
+  (let [line (read-line)]
+
+    (if (not= const/elser-comment (get line 0))
+      (try
+        (println (read-eval-print line))           
+        (catch Throwable e (clj-repl/pst e))))
+    
+    (recur)))
+
+(defn process-file
+  "
+  Apply compilation phases (to the content of a FILE)
+  that correspond to provided OPTIONS.
+  "
+  [file options]
   (let [code (slurp file)
         ast (READ (str "(" code ")") file)]
     (cond
-      (:ast options) 
-      (do (println "Generated AST:")
-          (clojure.pprint/pprint ast))
-
+      (:ast options)
+      (printer/pretty-print-phase "AST" ast)
+      
       (:symtable options)
-      (let [symbols (symtable/collect-symbols ast)]
-        (println "Generated symbol-table:")
-        (clojure.pprint/pprint symbols))
+      (printer/pretty-print-phase "SYMBOL TABLE" (symtable/collect-symbols ast))
 
       (:yul options)
-      (let [symbols (symtable/collect-symbols ast)
-            yul (compiler/symtable-to-yul symbols yul-env core/sto-ns)]
-        (println "Generated Yul:")
-        (println yul))
+      (printer/print-phase "YUL"
+                           (-> (symtable/collect-symbols ast)
+                               (compiler/symtable-to-yul yul-env core/sto-ns)))
+
 
       (:compile options)
       (let [symbols (symtable/collect-symbols ast)
-            _ (typecheck/check-types symbols types-env)
-            yul (compiler/symtable-to-yul symbols yul-env core/sto-ns)]
-        (do (evmcodegen/compile-to-evm yul (:ns symbols) (:pragma symbols))
-            (println "EVM bytecode was successfully generated.")))))
-  (System/exit 0))
+            _ (typecheck/check-types symbols types-env)]
+        
+        (printer/print-phase
+         
+         "EVM BYTECODE" (-> symbols
+                            (compiler/symtable-to-yul yul-env core/sto-ns)
+                            (evmcodegen/compile-to-evm (:ns symbols) (:pragma symbols))
+                            )))))
+  
+  (cli/exit 0))
   
 (defn -main [& args]
-  (let [{:keys [file options exit-message ok?]} (cli/validate-args args)]
+  (let [{:keys [file options exit-message ok?]} (cli/extract-cli-args args)]
+
     (when exit-message
       (cli/exit (if ok? 0 1) exit-message))
     

--- a/src/elser/main.clj
+++ b/src/elser/main.clj
@@ -2,7 +2,6 @@
   (:gen-class)
   (:require [elser.env :as env]
             [elser.reader :as reader]
-            [elser.printer :as printer]
             [elser.errors :as errs]
             [elser.core :as core]
             [elser.symtable :as symtable]
@@ -22,12 +21,12 @@
 (doseq [[k v] core/types-ns] (env/eset types-env k v))
 
 (defn READ
-  [inp]
-  (reader/read-str inp))
+  [inp src]
+  (reader/read-str inp src))
 
 (defn rep
   [inp]
-  (let [ast (READ inp)]
+  (let [ast (READ inp "./")]
     (symtable/collect-symbols `(constructor ~ast))))
 
 (defn repl-loop []
@@ -42,7 +41,7 @@
 
 (defn process-file [file options]
   (let [code (slurp file)
-        ast (READ (str "(" code ")"))]
+        ast (READ (str "(" code ")") file)]
     (cond
       (:ast options) 
       (do (println "Generated AST:")

--- a/src/elser/printer.clj
+++ b/src/elser/printer.clj
@@ -1,6 +1,7 @@
 (ns elser.printer
   (:gen-class)
-  (:require [clojure.string :as string]))
+  (:require [clojure.string :as string]
+            [clansi]))
 
 (defrecord ErrorMetadata [description chars path line pos])
 
@@ -10,13 +11,18 @@
 (defn fmt-err
   "Returns formatted error metadata."
   [metadata]
-  (println "metadata:" metadata)
   (str
    "\n"
    (format "| Error: %s" (:description metadata)) "\n"
    (format "| >>> %s" (:path metadata)) "\n"
-   (format "| L:%s \"%s\"" (:line metadata) (:chars metadata)) "\n"
+   (format "| L:%s %s" (:line metadata) (:chars metadata)) "\n"
    ))
+
+(defn highlight [char] (clansi/style char :inverse :underline :red))
+
+(defn highlight-char-in-ctx
+  [ctx char]
+  (string/replace ctx char (highlight char)))
 
 (defn esc [s]
   (-> s (string/replace "\\" "\\\\")

--- a/src/elser/printer.clj
+++ b/src/elser/printer.clj
@@ -1,13 +1,28 @@
 (ns elser.printer
   (:gen-class)
-  (:use [clojure.string :as string]))
+  (:require [clojure.string :as string]))
+
+(defrecord ErrorMetadata [description chars path line pos])
+
+(defn err-meta [description chars path line pos]
+  (ErrorMetadata. description chars path line pos))
+
+(defn fmt-err
+  "Returns formatted error metadata."
+  [metadata]
+  (str
+   "\n"
+   (format "| Error: %s" (:description metadata)) "\n"
+   (format "| >>> %s" (:path metadata)) "\n"
+   (format "| L:%s %s" (:line metadata) (:chars metadata)) "\n"
+   ))
 
 (defn esc [s]
   (-> s (string/replace "\\" "\\\\")
         (string/replace "\"" "\\\"")
         (string/replace "\n" "\\n")))
 
-(defn print-str
+(defn print-string
   "Takes generated AST and prints it as a string."
   ([ast] (print-str ast true))
   ([ast r?] 

--- a/src/elser/printer.clj
+++ b/src/elser/printer.clj
@@ -10,11 +10,12 @@
 (defn fmt-err
   "Returns formatted error metadata."
   [metadata]
+  (println "metadata:" metadata)
   (str
    "\n"
    (format "| Error: %s" (:description metadata)) "\n"
    (format "| >>> %s" (:path metadata)) "\n"
-   (format "| L:%s %s" (:line metadata) (:chars metadata)) "\n"
+   (format "| L:%s \"%s\"" (:line metadata) (:chars metadata)) "\n"
    ))
 
 (defn esc [s]

--- a/src/elser/reader.clj
+++ b/src/elser/reader.clj
@@ -7,22 +7,16 @@
 (def tokens-regex
   #"[\s,]*(~@|[\[\]{}()'`~^@]|\"(?:[\\].|[^\\\"])*\"?|;.*|[^\s\[\]{}()'\"`@,;]+)")
 
-;;----------------- TYPES -----------------
-
 (def badstr-regex #"^\"")
 (def str-regex #"^\"((?:[\\].|[^\\\"])*)\"$")
 (def int-regex #"^-?[0-9]+$")
-(def newline-regex #"\n+")
+(def newline-regex #"(?:\n\s*)+")
 
 (defrecord Token [char line])
 
 ;; Reader
-(defn rdr [tokens]
-  {:tokens tokens :pos (atom 0)})
-
-(defn ctx-add
-  [rdr token]
-  (swap! (:ctx rdr) conj token))
+(defn rdr [tokens ctx]
+  {:tokens tokens :pos (atom 0) :ctx ctx})
 
 (defn rnext
   "Returns a token in the current position
@@ -46,31 +40,40 @@
    (vec (rdr :tokens))
    (- @(:pos rdr) 1)))
 
+(defn get-line-ctx
+  "Return trimmed context string for line-number of raw-token."
+  [rdr raw-token]
+  (string/trim (get (:ctx rdr) (:line raw-token))))
+
 (defn tokenize-with-metadata
-  "Returns tokens with line metadata."
+  "Return a vector with a vector of tokens with line metadata, and context map."
   [in]
   (let [raw-tokens  (filter #(not= \; (first %))
                             (map first (re-seq tokens-regex in)))]
     (loop [line 1
            raw raw-tokens
-           tokens '[]]
+           tokens '[]
+           ctx '{}]
       
-      (if (= (count raw) 0)
-        tokens
+      (if (= (count raw) 0) [tokens ctx]
 
         (let [char (first raw)
-              newlines-count (count (re-find newline-regex char))
-              new-line (if (> newlines-count 0)
-                         (+ line newlines-count)
+              newlines (re-find newline-regex char)
+              new-line (if newlines
+                         (+ line (count (re-seq #"\n" newlines)))
                          line)]
-
-          (recur
-           
+          
+          (recur           
            new-line
            
            (next raw)
 
-           (conj tokens (Token. (string/trim char) new-line)))
+           (conj tokens (Token. (string/trim char) new-line))
+
+           (assoc ctx new-line
+                  (str (get ctx new-line) char))
+           )
+          
           ))
       )
     ))
@@ -81,7 +84,8 @@
   a list of tokens. Executes lexical
   analysis step."
   [in]
-  (rdr (tokenize-with-metadata in)))
+  (let [[tokens ctx] (tokenize-with-metadata in)]
+    (rdr tokens ctx)))
 
 (defn unesc [s]
   (-> s (string/replace "\\\\" "\u029e")
@@ -95,7 +99,7 @@
     (cond
       (re-seq int-regex token) (Integer/parseInt token)
       (re-seq str-regex token) (unesc (second (re-find str-regex token)))
-      (re-seq badstr-regex token) (errs/err-unexpected-tkn token)
+      (re-seq badstr-regex token) (errs/unexpected-token token)
       (= token "nil") nil
       (= \: (get token 0)) (keyword (subs token 1))
       (= token "true") true
@@ -105,7 +109,7 @@
 (declare read-form)
 
 (defn read-list [rdr beg end src]
-  (assert (= beg (:char (rnext rdr))))  
+  (assert (= beg (:char (rnext rdr))))
   (loop [lst []]
     
     (let [raw (rpeek rdr)
@@ -117,7 +121,7 @@
         (nil? token) (errs/err-throw
                       (printer/err-meta
                        (str "EOF before " "'" end "'")
-                       (str beg "..." end)
+                       (str beg " ... " end)
                        src
                        (:line (rback rdr))
                        ""))
@@ -130,7 +134,6 @@
   [rdr src]
   (let [raw (rpeek rdr)
         tkn (:char raw)]
-    ;; (prn "rpeek new:" (rpeek-beg-end rdr))
     (cond
       (= tkn "'") (do (rnext rdr) (list 'quote (read-form rdr src)))
       (= tkn "`") (do (rnext rdr) (list 'quasiquote (read-form rdr src)))
@@ -142,20 +145,20 @@
       (= tkn "^") (do (rnext rdr) (let [meta (read-form rdr src)
                                         data (read-form rdr src)]
                                     (list 'with-meta data meta)))
+      
       (= tkn ")") (errs/err-unbalanced tkn)
       (= tkn "(") (apply list (read-list rdr "(" ")" src))
 
       ;; Ban these brackets.
       (or (= tkn "]")
-          (= tkn "[")) (errs/err-throw
-                        (printer/err-meta "Unexpected token" tkn src (:line raw) ""))
-
-      (or (= tkn "}")
+          (= tkn "[")
+          (= tkn "}")
           (= tkn "{")) (errs/err-throw
-                        (printer/err-meta "Unexpected token" tkn src (:line raw) ""))
+                        (printer/err-meta (errs/unexpected-token tkn)
+                                          (printer/highlight-char-in-ctx
+                                           (get-line-ctx rdr raw) tkn)
+                                          src (:line raw) ""))
       
       :else (read-atom rdr src))))
 
-(defn read-str [in src]
-  (read-form
-   (tokenize in) src))
+(defn read-str [in src] (read-form (tokenize in) src))

--- a/src/elser/reader.clj
+++ b/src/elser/reader.clj
@@ -1,20 +1,28 @@
 (ns elser.reader
   (:gen-class)
   (:require [clojure.string :as string]
-            [elser.errors :as errs]))
+            [elser.errors :as errs]
+            [elser.printer :as printer]))
 
-(def TOKENS-REGEX
+(def tokens-regex
   #"[\s,]*(~@|[\[\]{}()'`~^@]|\"(?:[\\].|[^\\\"])*\"?|;.*|[^\s\[\]{}()'\"`@,;]+)")
 
-;----------------- TYPES -----------------
+;;----------------- TYPES -----------------
 
-(def BADSTR-REGEX #"^\"")
-(def STR-TYPE #"^\"((?:[\\].|[^\\\"])*)\"$")
-(def INT-TYPE #"^-?[0-9]+$")
+(def badstr-regex #"^\"")
+(def str-regex #"^\"((?:[\\].|[^\\\"])*)\"$")
+(def int-regex #"^-?[0-9]+$")
+(def newline-regex #"\n+")
+
+(defrecord Token [char line])
 
 ;; Reader
 (defn rdr [tokens]
   {:tokens tokens :pos (atom 0)})
+
+(defn ctx-add
+  [rdr token]
+  (swap! (:ctx rdr) conj token))
 
 (defn rnext
   "Returns a token in the current position
@@ -31,29 +39,56 @@
    (vec (rdr :tokens))
    @(:pos rdr)))
 
+(defn tokenize-with-metadata
+  "Returns tokens with line metadata."
+  [in]
+  (let [raw-tokens  (filter #(not= \; (first %))
+                            (map first (re-seq tokens-regex in)))]
+    (loop [line 1
+           raw raw-tokens
+           tokens '[]]
+      
+      (if (= (count raw) 0)
+        tokens
+
+        (let [char (first raw)
+              newlines-count (count (re-find newline-regex char))
+              new-line (if (> newlines-count 0)
+                         (+ line newlines-count)
+                         line)]
+
+          (recur
+           
+           new-line
+           
+           (next raw)
+
+           (conj tokens (Token. (string/trim char) new-line)))
+          ))
+      )
+    ))
+
 ;; Basically, this functon is a lexer
 (defn tokenize
   "Tokenizes an input string and returns
   a list of tokens. Executes lexical
   analysis step."
   [in]
-  (rdr
-   (filter (fn [x] (not= \; (first x)))
-           (map string/trim
-                (map second (re-seq TOKENS-REGEX in))))))
+  (rdr (tokenize-with-metadata in)))
 
 (defn unesc [s]
   (-> s (string/replace "\\\\" "\u029e")
-        (string/replace "\\\"" "\"")
-        (string/replace "\\n" "\n")
-        (string/replace "\u029e" "\\")))
+      (string/replace "\\\"" "\"")
+      (string/replace "\\n" "\n")
+      (string/replace "\u029e" "\\")))
 
-(defn read-atom [rdr]
-  (let [token (rnext rdr)]
+(defn read-atom [rdr src]
+  (let [raw (rnext rdr)
+        token (:char raw)]    
     (cond
-      (re-seq INT-TYPE token) (Integer/parseInt token)
-      (re-seq STR-TYPE token) (unesc (second (re-find STR-TYPE token)))
-      (re-seq BADSTR-REGEX token) (errs/err-unexpected-tkn token)
+      (re-seq int-regex token) (Integer/parseInt token)
+      (re-seq str-regex token) (unesc (second (re-find str-regex token)))
+      (re-seq badstr-regex token) (errs/err-unexpected-tkn token)
       (= token "nil") nil
       (= \: (get token 0)) (keyword (subs token 1))
       (= token "true") true
@@ -62,42 +97,51 @@
 
 (declare read-form)
 
-(defn read-list [rdr beg end]
-  (assert (= beg (rnext rdr)))
+(defn read-list [rdr beg end src]
+  (assert (= beg (:char (rnext rdr))))  
   (loop [lst []]
-    (let [token (rpeek rdr)]
+    
+    (let [raw (rpeek rdr)
+          token (:char raw)]
+      
       (cond
-        (= token end) (do (rnext rdr) lst)
-        (nil? token) (errs/err-eof-before-paren)
-        :else (recur (conj lst (read-form rdr)))))))
+        (= token end) (do (rnext rdr) lst)        
+        (nil? token) (errs/err-eof-before-paren)        
+        :else (recur (conj lst (read-form rdr src)))))))
 
 (defn read-form
   "Produces AST on tokenized input.
   Executes syntactical analysis step."
-  [rdr]
-  (let [tkn (rpeek rdr)]
+  [rdr src]
+  (let [raw (rpeek rdr)
+        tkn (:char raw)]
+    ;; (prn "rpeek new:" (rpeek-beg-end rdr))
     (cond
-      (= tkn "'") (do (rnext rdr) (list 'quote (read-form rdr)))
-      (= tkn "`") (do (rnext rdr) (list 'quasiquote (read-form rdr)))
-      (= tkn "~") (do (rnext rdr) (list 'unquote (read-form rdr)))
+      (= tkn "'") (do (rnext rdr) (list 'quote (read-form rdr src)))
+      (= tkn "`") (do (rnext rdr) (list 'quasiquote (read-form rdr src)))
+      (= tkn "~") (do (rnext rdr) (list 'unquote (read-form rdr src)))
+      
       ;; Permissions symbol => jump to the permissions map.
-      (= tkn "@") (do (rnext rdr) (list (read-form rdr)))
-      (= tkn "~@") (do (rnext rdr) (list 'splice-unquote (read-form rdr)))
-      (= tkn "^") (do (rnext rdr) (let [meta (read-form rdr)
-                                       data (read-form rdr)]
-                                   (list 'with-meta data meta)))
-      (= tkn ")") (errs/err-unbalanced "'( )'")
-      (= tkn "(") (apply list (read-list rdr "(" ")"))
+      (= tkn "@") (do (rnext rdr) (list (read-form rdr src)))
+      (= tkn "~@") (do (rnext rdr) (list 'splice-unquote (read-form rdr src)))
+      (= tkn "^") (do (rnext rdr) (let [meta (read-form rdr src)
+                                        data (read-form rdr src)]
+                                    (list 'with-meta data meta)))
+      (= tkn ")") (errs/err-unbalanced tkn)
+      (= tkn "(") (apply list (read-list rdr "(" ")" src))
       
       (= tkn "}") (errs/err-unbalanced "'{ }'")
-      (= tkn "{") (apply hash-map (read-list rdr "{" "}"))
+      (= tkn "{") (apply hash-map (read-list rdr "{" "}" src))
 
       ;; Ban these brackets.
       (= tkn "]") (errs/err-unexpected-tkn tkn)
-      (= tkn "[") (errs/err-unexpected-tkn tkn)
+      (= tkn "[") (do
+                    (printer/print-err
+                     (printer/err-meta "Unexpected token" tkn src (:line raw) ""))
+                    (errs/err-unexpected-tkn tkn))
       
-      :else (read-atom rdr))))
+      :else (read-atom rdr src))))
 
-(defn read-str [in]  
+(defn read-str [in src]
   (read-form
-   (tokenize in)))
+   (tokenize in) src))

--- a/src/elser/reader.clj
+++ b/src/elser/reader.clj
@@ -39,6 +39,13 @@
    (vec (rdr :tokens))
    @(:pos rdr)))
 
+(defn rback
+  "Returns the token at the previous position"
+  [rdr]
+  (get
+   (vec (rdr :tokens))
+   (- @(:pos rdr) 1)))
+
 (defn tokenize-with-metadata
   "Returns tokens with line metadata."
   [in]
@@ -103,10 +110,18 @@
     
     (let [raw (rpeek rdr)
           token (:char raw)]
-      
+
       (cond
-        (= token end) (do (rnext rdr) lst)        
-        (nil? token) (errs/err-eof-before-paren)        
+        (= token end) (do (rnext rdr) lst)
+        
+        (nil? token) (errs/err-throw
+                      (printer/err-meta
+                       (str "EOF before " "'" end "'")
+                       (str beg "..." end)
+                       src
+                       (:line (rback rdr))
+                       ""))
+        
         :else (recur (conj lst (read-form rdr src)))))))
 
 (defn read-form
@@ -129,16 +144,15 @@
                                     (list 'with-meta data meta)))
       (= tkn ")") (errs/err-unbalanced tkn)
       (= tkn "(") (apply list (read-list rdr "(" ")" src))
-      
-      (= tkn "}") (errs/err-unbalanced "'{ }'")
-      (= tkn "{") (apply hash-map (read-list rdr "{" "}" src))
 
       ;; Ban these brackets.
-      (= tkn "]") (errs/err-unexpected-tkn tkn)
-      (= tkn "[") (do
-                    (printer/print-err
-                     (printer/err-meta "Unexpected token" tkn src (:line raw) ""))
-                    (errs/err-unexpected-tkn tkn))
+      (or (= tkn "]")
+          (= tkn "[")) (errs/err-throw
+                        (printer/err-meta "Unexpected token" tkn src (:line raw) ""))
+
+      (or (= tkn "}")
+          (= tkn "{")) (errs/err-throw
+                        (printer/err-meta "Unexpected token" tkn src (:line raw) ""))
       
       :else (read-atom rdr src))))
 

--- a/src/elser/types.clj
+++ b/src/elser/types.clj
@@ -24,7 +24,7 @@
   )
 
 (def numeric [:u256 :i256])
-(def boolean [:bool])
+(def bool [:bool])
 (def addr [:addr])
 (def all [:u256 :i256 :bool :addr :b32])
 
@@ -135,7 +135,7 @@
   and returns required return type.
   "
   [x y ret-t]
-  (do (type-check-op boolean [(type-check x) (type-check y)])
+  (do (type-check-op bool [(type-check x) (type-check y)])
       ret-t))
 
 (defn type-check-all
@@ -166,7 +166,7 @@
 
 (defn type-check-bool-or-num
   [x y ret-t]
-  (do (type-check-op (into boolean numeric)  [(type-check x) (type-check y)])
+  (do (type-check-op (into bool numeric)  [(type-check x) (type-check y)])
       ret-t))
 
 (defn type-check-bool-unary
@@ -175,5 +175,5 @@
   and returns required return type.
   "
   [x ret-t]
-  (do (type-check-op boolean [(type-check x)])
+  (do (type-check-op bool [(type-check x)])
       ret-t))

--- a/test/elser/reader_test.clj
+++ b/test/elser/reader_test.clj
@@ -1,0 +1,89 @@
+(ns elser.reader-test
+  (:require [clojure.test :refer :all]
+            [elser.main :refer :all]
+            [elser.reader :refer :all]))
+
+;; All characters are wrapped in parentheses, because that's what's done
+;; in the elser.main before input is sent to the tokenization function.
+(def two-lines "(\n)")
+(def five-lines "(\n\n\n\n)")
+(def test-els "((ns test (:pragma \"0.8.29\"))
+
+(constructor
+ (sto write! x \"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\"))
+
+(events
+ (
+  (def xyz ((param0 :addr) (param1 :addr)))
+  ))
+
+(constants
+ (:internal
+  ( 
+   (def CONST (-> (:addr)) \"0x0000000000000000000000000000000000000000\")   
+   )))
+
+(storage
+ (:external
+  (
+   
+   (def slot0 (-> (x mut :addr)))
+   
+   )))
+
+(functions
+ (:external
+   
+   (defn doStuff ((param1 mut :addr)) (@sto :w 1 :r 1) (-> ())
+     (assert (!= param1 CONST))
+     (invoke! function2 param1))
+   
+   (defn function2 ((parameter mut :addr)) (@sto :w 1 :r 1) (-> ())
+     (sto write! slot0 parameter)
+     (invoke! doStuff CONST))
+   )
+  ))")
+
+(deftest test-tokenize-with-metadata-new-lines
+  (testing "Tokenize the source with line & pos metadata.")
+
+  (let [[tokens-2l ctx-2l] (tokenize-with-metadata two-lines)
+        [tokens-5l ctx-5l] (tokenize-with-metadata five-lines)]
+
+    ;; Verify "(\n)"
+    (let [token-0 (get tokens-2l 0)
+          token-1 (get tokens-2l 1)]
+      
+      (is (= (:char token-0) "("))
+      (is (= (:line token-0) 1))
+
+      (is (= (:char token-1) ")"))
+      (is (= (:line token-1) 2))
+
+      (is (= (get ctx-2l 1) "("))
+      (is (= (get ctx-2l 2) "\n)"))      
+      )
+
+    ;; Verify four new lines
+    (let [token-0 (get tokens-5l 0)
+          token-1 (get tokens-5l 1)]
+      
+      (is (= (:char token-0) "("))
+      (is (= (:line token-0) 1))
+
+      (is (= (:char token-1) ")"))
+      (is (= (:line token-1) 5))
+
+      (is (= (get ctx-5l 1) "("))
+      (is (= (get ctx-5l 5) "\n\n\n\n)"))      
+      )
+    ))
+
+(deftest test-tokenize-with-metadata-ownable
+  (testing "Tokens in program can be properly annotated with lines and pos metadata.")
+
+  (let [[tokens ctx] (tokenize-with-metadata test-els)
+        total-lines (:line (last tokens))]
+    
+    (is (= total-lines 36))
+    ))


### PR DESCRIPTION
## Overview
- Closes #17 

Errors will look ~like so:
```
| Error: Unexpected token: '['
| >>> examples/ownable.els
| L:29 (defn transferOwnership ((newOwner mut :addr)) [@sto :w 1 :r 1] (-> ())
```